### PR TITLE
Decrypt vault secrets in yaml

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -11,7 +11,7 @@
 
 - name: Copy autorestic config file
   copy:
-    content: "{{ autorestic_config_yaml | to_nice_yaml }}"
+    content: "{{ autorestic_config_yaml | to_json(vault_to_text=True) | from_json | to_nice_yaml }}"
     dest: "{{ autorestic_config_path }}"
     owner: "{{ autorestic_config_owner }}"
     group: "{{ autorestic_config_group }}"


### PR DESCRIPTION
The to_nice_yaml function (and to_yaml for that matter) doesn't decrypt vault secrets.  If you use ansible-vault for encoding keys in the `autorestic_config_yaml` property, those won't be decrypted, and will be pushed through to the client which, obviously, isn't going to be entirely happy with that ;)

```yaml
    - role: autorestic
      vars:
        autorestic_config_yaml:
          version: 2
          locations:
            data:
              from: 
                - /home
              to:
                - b2
          backends:
            b2:
              type: b2
              path: 'backup-test:{{inventory_hostname}}'
              key: !vault |
                $ANSIBLE_VAULT;1.1;AES256
                64.....
``` 

There is a unresolved issue with Ansible regarding this.
https://github.com/ansible/ansible/issues/77771

A solution is to round-trip the data through JSON since the [`to_json`](https://docs.ansible.com/ansible/devel/collections/ansible/builtin/to_json_filter.html) method does support converting vault_secrets to text.

While not ideal, I think the above solution is a useful extension to this role in lieu of an upstream fix in Ansible. 
