### PR TITLE
Set autorestic_config_directory and create directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Other variables that can be changed:
 ```yaml
 autorestic_config_user: root
 autorestic_config_yaml: CHANGEME  # autorestic configuration in yaml
-autorestic_config_path: "{{ autorestic_user_directory }}/.autorestic.yml"
+autorestic_config_directory: /home/{{ autorestic_config_user }}/.config/autorestic
+autorestic_config_path: "{{ autorestic_config_directory }}/.autorestic.yml"
 autorestic_config_mode: 0600
 autorestic_config_owner: "{{ autorestic_config_user }}"
 autorestic_config_group: "{{ autorestic_config_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,8 @@ autorestic_install_path: "{{ autorestic_install_directory }}/autorestic"
 ### Autorestic Config
 autorestic_config_user: root
 autorestic_config_yaml: CHANGEME  # autorestic configuration in yaml
-autorestic_config_path: "{{ autorestic_user_directory }}/.autorestic.yml"
+autorestic_config_directory: /home/{{ autorestic_config_user }}/.config/autorestic
+autorestic_config_path: "{{ autorestic_config_directory }}/.autorestic.yml"
 autorestic_config_mode: "0600"
 autorestic_config_owner: "{{ autorestic_config_user }}"
 autorestic_config_group: "{{ autorestic_config_user }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,13 +9,13 @@
   ansible.builtin.set_fact:
     autorestic_user_directory: "{{ autorestic_user_register.home }}"
 
-- name: create autorestic_config_path
-  file:
+- name: Create autorestic_config_path
+  ansible.builtin.file:
     path: "{{ autorestic_config_directory }}"
     owner: "{{ autorestic_config_owner }}"
     group: "{{ autorestic_config_group }}"
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Copy autorestic config file
   ansible.builtin.copy:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,6 +9,14 @@
   ansible.builtin.set_fact:
     autorestic_user_directory: "{{ autorestic_user_register.home }}"
 
+- name: create autorestic_config_path
+  file:
+    path: "{{ autorestic_config_directory }}"
+    owner: "{{ autorestic_config_owner }}"
+    group: "{{ autorestic_config_group }}"
+    state: directory
+    mode: 0755
+
 - name: Copy autorestic config file
   ansible.builtin.copy:
     content: "{{ autorestic_config_yaml | to_json(vault_to_text=True) | from_json | to_nice_yaml }}"


### PR DESCRIPTION
Fixes #5 

Changed `autorestic_user_directory` to `autorestic_config_directory` to be more consistent, added check to make sure directory exists.