### PR TITLE
allow role to run in --check mode

### DIFF
--- a/tasks/install_restic.yml
+++ b/tasks/install_restic.yml
@@ -22,6 +22,7 @@
     return_content: true
     force_basic_auth: "{{ github_api_auth | default(omit) }}"
   register: release_version_registered
+  check_mode: false
   when: restic_download_latest_ver == True
 
 - name: Set restic version (latest)


### PR DESCRIPTION
Makes sure github fetch happens even if --check is enabled. To have registered latest version variable.


Fixes: #4 