### PR TITLE
Fix non-representative results in check mode

### DIFF
--- a/tasks/install_autorestic.yml
+++ b/tasks/install_autorestic.yml
@@ -12,6 +12,7 @@
   ansible.builtin.shell: "{{ is_installed.stat.path }} --version | grep -oP 'autorestic\\ version\ \\K[0-9]*\\.[0-9]*\\.[0-9]*'"
   register: installed_version_registered
   changed_when: false
+  check_mode: false
   when: autorestic_is_installed == True
 
 - name: Get latest GH autorestic version

--- a/tasks/install_restic.yml
+++ b/tasks/install_restic.yml
@@ -12,6 +12,7 @@
   ansible.builtin.shell: "{{ is_installed.stat.path }} version | grep -oP 'restic\\ \\K[0-9]*\\.[0-9]*\\.[0-9]*'"
   register: installed_version_registered
   changed_when: false
+  check_mode: false
   when: restic_is_installed == True
 
 - name: Get latest GH restic version


### PR DESCRIPTION
Fixes non-representative results in check mode by always checking the installed versions of restic and autorestic.

Without this, the role always thinks it needs to download & install/update.