### PR TITLE
make role check mode compatible

### DIFF
--- a/tasks/install_autorestic.yml
+++ b/tasks/install_autorestic.yml
@@ -24,6 +24,7 @@
     force_basic_auth: "{{ github_api_auth | default(omit) }}"
   register: release_version_registered
   when: autorestic_download_latest_ver == True
+  check_mode: false
 
 - name: Set autorestic version (latest)
   ansible.builtin.set_fact:


### PR DESCRIPTION
Fixes:

 {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'json'\n\nThe error appears to be in '/xxx/roles/fuzzymistborn.autorestic/tasks/install_autorestic.yml': line 29, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set autorestic version (latest)\n  ^ here\n"}