### PR TITLE
Access facts via `ansible_facts` namespace

### DIFF
--- a/tasks/install_autorestic.yml
+++ b/tasks/install_autorestic.yml
@@ -74,4 +74,4 @@
     - name: Fedora - SELinux Fix
       ansible.builtin.command: restorecon -Rv /usr/local/bin
       become: true
-      when: ansible_distribution == 'Fedora'
+      when: ansible_facts.distribution == 'Fedora'

--- a/tasks/install_restic.yml
+++ b/tasks/install_restic.yml
@@ -74,4 +74,4 @@
     - name: Fedora - SELinux Fix
       ansible.builtin.command: restorecon -Rv /usr/local/bin
       become: true
-      when: ansible_distribution == 'Fedora'
+      when: ansible_facts.distribution == 'Fedora'


### PR DESCRIPTION
This allows the role to be used with ansible-core 2.20 without workarounds.

It also helps anyone using older versions of ansible-core if `INJECT_FACTS_AS_VARS` is set to `False`.